### PR TITLE
Add @Atomic property wrapper for class

### DIFF
--- a/FoundationExtension/Extensions/Atomic.swift
+++ b/FoundationExtension/Extensions/Atomic.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-public class Atomic<T> {
+@propertyWrapper
+public final class Atomic<T> {
     private let semaphore = DispatchSemaphore(value: 1)
     private var _value: T
 
-    public var value: T {
+    public var wrappedValue: T {
         get {
             wait()
             let result = _value
@@ -43,7 +44,7 @@ public class Atomic<T> {
         semaphore.signal()
     }
 
-    public init(value: T) {
-        _value = value
+    public init(wrappedValue: T) {
+        _value = wrappedValue
     }
 }


### PR DESCRIPTION
Привет, решил что такая возможность не будет лишней.

Вместо того, чтобы стучаться по свойству ```value``` можно использовать переменную напрямую, указав атрибут ```@Atomic```.

Пример использования
```
@Atomic var array: [Int] = []

func testExample() {
    for index in 1...10000 {
    let writeQueue = DispatchQueue(label: "write_queue", attributes: .concurrent)
    let readQueue = DispatchQueue(label: "read_queue", attributes: .concurrent)

    writeQueue.async {
        self.array.append(index)
    }

    readQueue.async {
        print(self.array.last)
    }
}
```