### PR TITLE
[NEW FEATURE] Create and implement custom dialog with content view

### DIFF
--- a/FoundationExtension/Source/DialogService/DialogService.swift
+++ b/FoundationExtension/Source/DialogService/DialogService.swift
@@ -61,6 +61,11 @@ public protocol DialogService {
     // MARK: - share
 
     func showShareDialog(items: [DialogServiceShareItem])
+    
+    // MARK: - Custom alerts
+    
+    func showCustomDialog(with content: UIView)
+    func hideCustomDialog()
 }
 
 public protocol DialogServiceShareItem {}

--- a/FoundationExtension/Source/DialogService/DialogServiceImpl.swift
+++ b/FoundationExtension/Source/DialogService/DialogServiceImpl.swift
@@ -424,7 +424,7 @@ open class DialogServiceImpl: NSObject, DialogService, UIPickerViewDataSource, U
         vOverlay?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(hideCustomDialog)))
         
         // Setup dialog view
-        let horizonalPadding: CGFloat = 16
+        let horizontalPadding: CGFloat = 16
         let squareWidth: CGFloat = UIScreen.main.bounds.width - (horizonalPadding * 2)
         let contentSize = CGSize(width: squareWidth, height: squareWidth)
         let topSafeAreaInset = safeAreaTopInset(for: viewController)


### PR DESCRIPTION
Доброго времени суток

Обновил dialogService, добавил в него возможность отображения кастомного диалога с оверлеем

Вкратце:
На контроллер накидывается оверлей (черный, альфа 30%) с жестом, по тапу - скрываем диалог
Сам диалог состоит из квадратного контент вью, поверх которого накинута кнопка Close, которая так же скрывает диалог

Сам метод принимает вью, для размещения в качестве контента в диалоге. 

Пример использования будет ниже

<img src="https://user-images.githubusercontent.com/97443104/208468870-8c8faf91-8243-4b4e-9d27-3d611e014d0e.png" width=250>

(под диалогом специально закрыт контент)

